### PR TITLE
Fixing a xib and EN localisation file

### DIFF
--- a/Example/OTAppaloosaDemo/OTAppaloosaDemo/Classes/Controller/OTViewController~ipad.xib
+++ b/Example/OTAppaloosaDemo/OTAppaloosaDemo/Classes/Controller/OTViewController~ipad.xib
@@ -240,23 +240,6 @@
 							</object>
 						</object>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
-						<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-							<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-							<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-								<bool key="EncodedWithXMLCoder">YES</bool>
-								<array key="dict.sortedKeys">
-									<integer value="1"/>
-									<integer value="3"/>
-								</array>
-								<array key="dict.values">
-									<string>{320, 568}</string>
-									<string>{568, 320}</string>
-								</array>
-							</object>
-							<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-							<string key="IBUIDisplayName">Retina 4 Full Screen</string>
-							<int key="IBUIType">2</int>
-						</object>
 						<string key="targetRuntimeIdentifier">IBIPadFramework</string>
 					</object>
 				</array>

--- a/OTAppaloosa/Resources/en.lproj/Localizable.strings
+++ b/OTAppaloosa/Resources/en.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 
 /* OTAppaloosaAgent */
 
-"An update is available. Would you like to update?”;
+"An update is available. Would you like to update?";
 
 /* OTAppaloosaInAppFeedbackViewController */
 
@@ -26,4 +26,4 @@
 
 "Cellular";
 "WiFi";
-"No Connection”;
+"No Connection";


### PR DESCRIPTION
Removing smart quotes on EN localisation file
Removing (certainly) deprecated xib attribute